### PR TITLE
adding the amount of transaction written into innodb logs

### DIFF
--- a/myq_innodb_status
+++ b/myq_innodb_status
@@ -403,7 +403,7 @@ LOOP: while( 1 ) {
             'log_io/s',
 	    'Chpt Age',
 	    'Pct fill',
-	    'Data'
+	    'Mb W'
         ) if( $count % $lines_per_header == 0 );
         printf( "%s % 8s % 8s % 8s % 8s % 8s", 
             $pretty_time, 
@@ -415,7 +415,7 @@ LOOP: while( 1 ) {
                              $innodb_status->{log_checkpoint_at}),
                             ($variables->{innodb_log_file_size} *
                              $variables->{innodb_log_files_in_group}), 2, 6),
-            &format_memory( &counter_diff( 'log_sequence_number' ), 2, 6 )
+            &format_number( &counter_diff( 'log_sequence_number' )/1024/1024, 2, 6 )
         );
     } elsif( $MODE eq 'extralog' ) {
         printf( "log      % 8s % 8s % 8s % 8s\n",


### PR DESCRIPTION
Signed-off-by: Frederic -lefred- Descamps lefred@percona.com

output looks like this:

[percona@db02 ~]$ ./myq_innodb_status log
log        log_io log_io/s Chpt Age      M/s  
05:26:22   34.89m   428.95   629.9M    8.38T
05:27:22    7.53k   125.55   630.7M    5.79M
05:28:22    5.73k    95.45   628.9M    4.18M
05:29:23    7.37k   120.85   620.4M    6.30M
05:30:22    5.57k    94.44   616.7M    5.43M
05:31:22    8.01k   133.55   613.8M    8.08M
05:32:22    9.11k   151.85   617.7M    9.11M
