### PR TITLE
use findbin::realbin so the scripts can be symlinked to the user path

### DIFF
--- a/myq_innodb_status
+++ b/myq_innodb_status
@@ -7,7 +7,24 @@
 use strict;
 
 use FindBin;
-use lib "$FindBin::RealBin";
+
+# Users can symlink this script and it will still add the correct locations to 
+# perls path using FindBin::RealBin, but to ensure compatibility with old perl
+# we need to be a bit more clever    
+sub get_lib {
+    # Start with a sensible default
+    my $bin_path = $FindBin::Bin;
+    {
+        no warnings 'uninitialized';
+        my $real_path="$FindBin::RealBin";   #This may fail on Perl < 5.10
+        if ($real_path ne ''){               # if the value is set, we'll use it
+            $bin_path = $real_path;
+        }
+    }
+    return $bin_path;
+}
+
+use lib get_lib();
 
 use MySQL_Script_Utils;
 

--- a/myq_innodb_status
+++ b/myq_innodb_status
@@ -7,7 +7,7 @@
 use strict;
 
 use FindBin;
-use lib "$FindBin::Bin";
+use lib "$FindBin::RealBin";
 
 use MySQL_Script_Utils;
 

--- a/myq_slave_info
+++ b/myq_slave_info
@@ -7,7 +7,25 @@
 use strict;
 
 use FindBin;
-use lib "$FindBin::RealBin";
+
+
+# Users can symlink this script and it will still add the correct locations to 
+# perls path using FindBin::RealBin, but to ensure compatibility with old perl
+# we need to be a bit more clever    
+sub get_lib {
+    # Start with a sensible default
+    my $bin_path = $FindBin::Bin;
+    {
+        no warnings 'uninitialized';
+        my $real_path="$FindBin::RealBin";   #This may fail on Perl < 5.10
+        if ($real_path ne ''){               # if the value is set, we'll use it
+            $bin_path = $real_path;
+        }
+    }
+    return $bin_path;
+}
+
+use lib get_lib();
 
 use MySQL_Script_Utils;
 

--- a/myq_slave_info
+++ b/myq_slave_info
@@ -7,7 +7,7 @@
 use strict;
 
 use FindBin;
-use lib "$FindBin::Bin";
+use lib "$FindBin::RealBin";
 
 use MySQL_Script_Utils;
 

--- a/myq_status
+++ b/myq_status
@@ -12,7 +12,7 @@ binmode(STDOUT, ":utf8");
 
 
 use FindBin;
-use lib "$FindBin::Bin";
+use lib "$FindBin::RealBin";
 
 use MySQL_Script_Utils;
 

--- a/myq_status
+++ b/myq_status
@@ -10,9 +10,25 @@ use strict;
 use utf8;
 binmode(STDOUT, ":utf8");
 
-
 use FindBin;
-use lib "$FindBin::RealBin";
+
+# Users can symlink this script and it will still add the correct locations to 
+# perls path using FindBin::RealBin, but to ensure compatibility with old perl
+# we need to be a bit more clever    
+sub get_lib {
+    # Start with a sensible default
+    my $bin_path = $FindBin::Bin;
+    {
+        no warnings 'uninitialized';
+        my $real_path="$FindBin::RealBin";   #This may fail on Perl < 5.10
+        if ($real_path ne ''){               # if the value is set, we'll use it
+            $bin_path = $real_path;
+        }
+    }
+    return $bin_path;
+}
+
+use lib get_lib();
 
 use MySQL_Script_Utils;
 

--- a/tester
+++ b/tester
@@ -12,8 +12,24 @@ binmode(STDOUT, ":utf8");
 
 
 use FindBin;
-use lib "$FindBin::Bin";
 
+# Users can symlink this script and it will still add the correct locations to 
+# perls path using FindBin::RealBin, but to ensure compatibility with old perl
+# we need to be a bit more clever    
+sub get_lib {
+    # Start with a sensible default
+    my $bin_path = $FindBin::Bin;
+    {
+        no warnings 'uninitialized';
+        my $real_path="$FindBin::RealBin";   #This may fail on Perl < 5.10
+        if ($real_path ne ''){               # if the value is set, we'll use it
+            $bin_path = $real_path;
+        }
+    }
+    return $bin_path;
+}
+
+use lib get_lib();
 use MySQL_Script_Utils;
 
 sub assert {


### PR DESCRIPTION
I wanted to install these scripts to /usr/local/src/myq_gadgets and then symlink to the scripts themselves into /usr/local/bin/ but the symlink resulted in a failure to resolve the mysql_script_utils library as the lib path was incorrect.

I've changed to realbin which resolves the 'real' location of the script, enabling symlinked scripts to work as expected.
